### PR TITLE
Change documentation link url to github

### DIFF
--- a/clean_code_main/clean_code_checks/y_check_base.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_base.clas.abap
@@ -145,7 +145,7 @@ CLASS Y_CHECK_BASE IMPLEMENTATION.
     settings-threshold = 5.
     settings-apply_on_productive_code = abap_true.
     settings-apply_on_test_code = abap_true.
-    settings-documentation = 'https://github.wdf.sap.corp/CleanCode/code-pal/blob/master/docs/check_documentation.md' ##NO_TEXT.
+    settings-documentation = 'https://github.com/SAP/code-pal-for-abap/blob/master/docs/check_documentation.md' ##NO_TEXT.
 
     has_attributes = do_attributes_exist( ).
 


### PR DESCRIPTION
Documentation link pointing to internal SAP gitlab at the moment should be changed to github / public url.