### PR TITLE
Call the specific check documentation

### DIFF
--- a/clean_code_main/clean_code_checks/y_check_base.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_base.clas.abap
@@ -10,7 +10,12 @@ CLASS y_check_base DEFINITION ABSTRACT
         error        TYPE sci_errc VALUE '100',
         warning      TYPE sci_errc VALUE '101',
         notification TYPE sci_errc VALUE '102',
-      END OF c_code .
+      END OF c_code,
+      BEGIN OF c_docs_path,
+        main   TYPE string VALUE 'https://github.com/SAP/code-pal-for-abap/blob/master/docs/' ##NO_TEXT,
+        checks TYPE string VALUE 'https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/' ##NO_TEXT,
+      END OF c_docs_path.
+
     DATA:
       BEGIN OF settings READ-ONLY,
         pseudo_comment                TYPE sci_pcom,
@@ -68,7 +73,7 @@ CLASS y_check_base DEFINITION ABSTRACT
       RETURNING
         VALUE(result) TYPE sci_errc .
     METHODS inspect_tokens
-      ABSTRACT
+          ABSTRACT
       IMPORTING
         !structure TYPE sstruc OPTIONAL
         !index     TYPE i OPTIONAL
@@ -122,7 +127,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_BASE IMPLEMENTATION.
+CLASS y_check_base IMPLEMENTATION.
 
 
   METHOD check_start_conditions.
@@ -144,7 +149,7 @@ CLASS Y_CHECK_BASE IMPLEMENTATION.
     settings-threshold = 5.
     settings-apply_on_productive_code = abap_true.
     settings-apply_on_test_code = abap_true.
-    settings-documentation = 'https://github.com/SAP/code-pal-for-abap/blob/master/docs/check_documentation.md' ##NO_TEXT.
+    settings-documentation = |{ c_docs_path-main }check_documentation.md|.
 
     has_attributes = do_attributes_exist( ).
 

--- a/clean_code_main/clean_code_checks/y_check_call_method_usage.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_call_method_usage.clas.abap
@@ -15,7 +15,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_CALL_METHOD_USAGE IMPLEMENTATION.
+CLASS y_check_call_method_usage IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -30,6 +30,7 @@ CLASS Y_CHECK_CALL_METHOD_USAGE IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CALL_METH_USAGE' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }call-method-usage.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_check_stmnt_position.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_check_stmnt_position.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_CHECK_STMNT_POSITION IMPLEMENTATION.
+CLASS y_check_check_stmnt_position IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -40,6 +40,7 @@ CLASS Y_CHECK_CHECK_STMNT_POSITION IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CHECK_POSITION' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }check-statement-position.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_comment_usage.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_comment_usage.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_COMMENT_USAGE IMPLEMENTATION.
+CLASS y_check_comment_usage IMPLEMENTATION.
 
 
   METHOD calc_percentage_of_comments.
@@ -76,6 +76,7 @@ CLASS Y_CHECK_COMMENT_USAGE IMPLEMENTATION.
 
     settings-prio = 'N'.
     settings-threshold = 10.
+    settings-documentation = |{ c_docs_path-checks }comment-usage.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_constants_interface.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_constants_interface.clas.abap
@@ -19,7 +19,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_CONSTANTS_INTERFACE IMPLEMENTATION.
+CLASS y_check_constants_interface IMPLEMENTATION.
 
 
   METHOD checkif_error.
@@ -53,6 +53,7 @@ CLASS Y_CHECK_CONSTANTS_INTERFACE IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CONS_INTF' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }constants-interface.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_cyclomatic_complexity.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_cyclomatic_complexity.clas.abap
@@ -31,7 +31,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_CYCLOMATIC_COMPLEXITY IMPLEMENTATION.
+CLASS y_check_cyclomatic_complexity IMPLEMENTATION.
 
 
   METHOD compute_cyclomatic_complexity.
@@ -64,6 +64,7 @@ CLASS Y_CHECK_CYCLOMATIC_COMPLEXITY IMPLEMENTATION.
 
     settings-pseudo_comment = '"#EC CI_CYCLO' ##NO_TEXT.
     settings-threshold = 10.
+    settings-documentation = |{ c_docs_path-checks }cyclomatic-complexity.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_db_access_in_ut.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_db_access_in_ut.clas.abap
@@ -28,7 +28,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_DB_ACCESS_IN_UT IMPLEMENTATION.
+CLASS y_check_db_access_in_ut IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -47,6 +47,7 @@ CLASS Y_CHECK_DB_ACCESS_IN_UT IMPLEMENTATION.
     settings-threshold = 0.
     settings-apply_on_productive_code = abap_false.
     settings-apply_on_test_code = abap_true.
+    settings-documentation = |{ c_docs_path-checks }db-access-in-ut.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_declaration_in_if.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_declaration_in_if.clas.abap
@@ -23,7 +23,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_DECLARATION_IN_IF IMPLEMENTATION.
+CLASS y_check_declaration_in_if IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -39,6 +39,7 @@ CLASS Y_CHECK_DECLARATION_IN_IF IMPLEMENTATION.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
     settings-prio = 'W'.
+    settings-documentation = |{ c_docs_path-checks }declaration-in-if.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_deprecated_key_words.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_deprecated_key_words.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_DEPRECATED_KEY_WORDS IMPLEMENTATION.
+CLASS y_check_deprecated_key_words IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -33,6 +33,7 @@ CLASS Y_CHECK_DEPRECATED_KEY_WORDS IMPLEMENTATION.
     settings-pseudo_comment = '"#EC DEPRECATED_KEY' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }deprecated-key-word.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_empty_if_branches.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_empty_if_branches.clas.abap
@@ -38,7 +38,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_EMPTY_IF_BRANCHES IMPLEMENTATION.
+CLASS y_check_empty_if_branches IMPLEMENTATION.
 
 
   METHOD begin_of_statement.
@@ -96,6 +96,7 @@ CLASS Y_CHECK_EMPTY_IF_BRANCHES IMPLEMENTATION.
     settings-pseudo_comment = '"#EC EMPTY_IF_BRANCH' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }empty-if-branches.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_empty_procedures.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_empty_procedures.clas.abap
@@ -33,7 +33,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_EMPTY_PROCEDURES IMPLEMENTATION.
+CLASS y_check_empty_procedures IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -49,6 +49,7 @@ CLASS Y_CHECK_EMPTY_PROCEDURES IMPLEMENTATION.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
     settings-prio = 'W'.
+    settings-documentation = |{ c_docs_path-checks }empty-procedure.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_equals_sign_chaining.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_equals_sign_chaining.clas.abap
@@ -11,7 +11,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_EQUALS_SIGN_CHAINING IMPLEMENTATION.
+CLASS y_check_equals_sign_chaining IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -20,7 +20,7 @@ CLASS Y_CHECK_EQUALS_SIGN_CHAINING IMPLEMENTATION.
     category    = 'Y_CHECK_CATEGORY'.
     version     = '0000'.
     position    = '320'.
-    has_documentation = abap_true.
+    has_documentation = abap_false.
 
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 1.

--- a/clean_code_main/clean_code_checks/y_check_form.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_form.clas.abap
@@ -19,7 +19,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_FORM IMPLEMENTATION.
+CLASS y_check_form IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -34,6 +34,7 @@ CLASS Y_CHECK_FORM IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CI_FORM' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }form-routine.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_function.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_function.clas.abap
@@ -21,7 +21,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_FUNCTION IMPLEMENTATION.
+CLASS y_check_function IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -36,6 +36,7 @@ CLASS Y_CHECK_FUNCTION IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CI_FUNCTION' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }function-routine.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_is_interface_in_class.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_is_interface_in_class.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_IS_INTERFACE_IN_CLASS IMPLEMENTATION.
+CLASS y_check_is_interface_in_class IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -33,6 +33,7 @@ CLASS Y_CHECK_IS_INTERFACE_IN_CLASS IMPLEMENTATION.
     settings-pseudo_comment = '"#EC INTF_IN_CLASS' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }interface-in-class.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_magic_number.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_magic_number.clas.abap
@@ -35,7 +35,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_MAGIC_NUMBER IMPLEMENTATION.
+CLASS y_check_magic_number IMPLEMENTATION.
 
 
   METHOD constructor .
@@ -51,6 +51,7 @@ CLASS Y_CHECK_MAGIC_NUMBER IMPLEMENTATION.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
     settings-apply_on_test_code = abap_false.
+    settings-documentation = |{ c_docs_path-checks }magic-number.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_max_nesting_depth.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_max_nesting_depth.clas.abap
@@ -30,7 +30,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_MAX_NESTING_DEPTH IMPLEMENTATION.
+CLASS y_check_max_nesting_depth IMPLEMENTATION.
 
 
   METHOD compute_nesting_level.
@@ -60,6 +60,7 @@ CLASS Y_CHECK_MAX_NESTING_DEPTH IMPLEMENTATION.
     has_documentation = abap_true.
 
     settings-pseudo_comment = '"#EC CI_NESTING' ##NO_TEXT.
+    settings-documentation = |{ c_docs_path-checks }maximum-nesting-depth.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_method_output_param.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_method_output_param.clas.abap
@@ -26,7 +26,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_METHOD_OUTPUT_PARAM IMPLEMENTATION.
+CLASS y_check_method_output_param IMPLEMENTATION.
 
 
   METHOD calculate_param_combination.
@@ -66,6 +66,7 @@ CLASS Y_CHECK_METHOD_OUTPUT_PARAM IMPLEMENTATION.
     settings-pseudo_comment = '"#EC PARAMETER_OUT' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 1.
+    settings-documentation = |{ c_docs_path-checks }method-output-parameter.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_method_return_bool.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_method_return_bool.clas.abap
@@ -28,7 +28,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_METHOD_RETURN_BOOL IMPLEMENTATION.
+CLASS y_check_method_return_bool IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -44,6 +44,7 @@ CLASS Y_CHECK_METHOD_RETURN_BOOL IMPLEMENTATION.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
     settings-prio = 'W'.
+    settings-documentation = |{ c_docs_path-checks }method-return-bool.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_non_class_exception.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_non_class_exception.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NON_CLASS_EXCEPTION IMPLEMENTATION.
+CLASS y_check_non_class_exception IMPLEMENTATION.
 
 
   METHOD checkif_error.
@@ -51,6 +51,7 @@ CLASS Y_CHECK_NON_CLASS_EXCEPTION IMPLEMENTATION.
     settings-pseudo_comment = '"#EC NON_CL_EXCEPT' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }non-class-exception.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_num_exec_statements.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_num_exec_statements.clas.abap
@@ -40,7 +40,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUM_EXEC_STATEMENTS IMPLEMENTATION.
+CLASS y_check_num_exec_statements IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -54,6 +54,7 @@ CLASS Y_CHECK_NUM_EXEC_STATEMENTS IMPLEMENTATION.
 
     settings-pseudo_comment = '"#EC CI_NOES' ##NO_TEXT.
     settings-threshold = 40.
+    settings-documentation = |{ c_docs_path-checks }number-executable-statements.md|.
 
     add_obj_type( c_type_program ).
 

--- a/clean_code_main/clean_code_checks/y_check_num_output_parameter.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_num_output_parameter.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUM_OUTPUT_PARAMETER IMPLEMENTATION.
+CLASS y_check_num_output_parameter IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -39,6 +39,7 @@ CLASS Y_CHECK_NUM_OUTPUT_PARAMETER IMPLEMENTATION.
     settings-pseudo_comment = '"#EC NUM_OUTPUT_PARA' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 1.
+    settings-documentation = |{ c_docs_path-checks }number-output-parameter.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_num_public_attributes.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_num_public_attributes.clas.abap
@@ -37,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUM_PUBLIC_ATTRIBUTES IMPLEMENTATION.
+CLASS y_check_num_public_attributes IMPLEMENTATION.
 
 
   METHOD checkif_attribute_in_structure.
@@ -91,6 +91,7 @@ CLASS Y_CHECK_NUM_PUBLIC_ATTRIBUTES IMPLEMENTATION.
     settings-pseudo_comment = '"#EC NUM_PUBLIC_ATTR' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }number-public-attributes.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_number_attributes.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_number_attributes.clas.abap
@@ -31,7 +31,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUMBER_ATTRIBUTES IMPLEMENTATION.
+CLASS y_check_number_attributes IMPLEMENTATION.
 
 
   METHOD checkif_attribute_found.
@@ -85,6 +85,7 @@ CLASS Y_CHECK_NUMBER_ATTRIBUTES IMPLEMENTATION.
 
     settings-pseudo_comment = '"#EC NUMBER_ATTR' ##NO_TEXT.
     settings-threshold = 12.
+    settings-documentation = |{ c_docs_path-checks }number-attributes.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_number_events.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_number_events.clas.abap
@@ -20,7 +20,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUMBER_EVENTS IMPLEMENTATION.
+CLASS y_check_number_events IMPLEMENTATION.
 
 
   METHOD checkif_error.
@@ -54,6 +54,7 @@ CLASS Y_CHECK_NUMBER_EVENTS IMPLEMENTATION.
     has_documentation = abap_true.
 
     settings-pseudo_comment = '"#EC NUMBER_EVENTS' ##NO_TEXT.
+    settings-documentation = |{ c_docs_path-checks }number-events.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_number_interfaces.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_number_interfaces.clas.abap
@@ -21,7 +21,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUMBER_INTERFACES IMPLEMENTATION.
+CLASS y_check_number_interfaces IMPLEMENTATION.
 
 
   METHOD checkif_error.
@@ -56,6 +56,7 @@ CLASS Y_CHECK_NUMBER_INTERFACES IMPLEMENTATION.
 
     settings-pseudo_comment = '"#EC NMBR_INTERFACES' ##NO_TEXT.
     settings-threshold = 4.
+    settings-documentation = |{ c_docs_path-checks }number-interfaces.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_number_methods.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_number_methods.clas.abap
@@ -23,7 +23,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_NUMBER_METHODS IMPLEMENTATION.
+CLASS y_check_number_methods IMPLEMENTATION.
 
 
   METHOD checkif_error.
@@ -60,6 +60,7 @@ CLASS Y_CHECK_NUMBER_METHODS IMPLEMENTATION.
 
     settings-pseudo_comment = '"#EC NUMBER_METHODS' ##NO_TEXT.
     settings-threshold = 20.
+    settings-documentation = |{ c_docs_path-checks }number-methods.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_receiving_usage.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_receiving_usage.clas.abap
@@ -16,7 +16,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_RECEIVING_USAGE IMPLEMENTATION.
+CLASS y_check_receiving_usage IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -31,6 +31,7 @@ CLASS Y_CHECK_RECEIVING_USAGE IMPLEMENTATION.
     settings-pseudo_comment = '"#EC RECEIVING_USAGE' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }receiving-usage.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_sub_assign_read_table.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_sub_assign_read_table.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_SUB_ASSIGN_READ_TABLE IMPLEMENTATION.
+CLASS y_check_sub_assign_read_table IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -33,6 +33,7 @@ CLASS Y_CHECK_SUB_ASSIGN_READ_TABLE IMPLEMENTATION.
     settings-pseudo_comment = '"#EC SUB_ASSIGN' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }sub-assign-read-table.md|.
 
     y_message_registration=>add_message(
       EXPORTING

--- a/clean_code_main/clean_code_checks/y_check_test_seam_usage.clas.abap
+++ b/clean_code_main/clean_code_checks/y_check_test_seam_usage.clas.abap
@@ -16,7 +16,7 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_TEST_SEAM_USAGE IMPLEMENTATION.
+CLASS y_check_test_seam_usage IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -31,6 +31,7 @@ CLASS Y_CHECK_TEST_SEAM_USAGE IMPLEMENTATION.
     settings-pseudo_comment = '"#EC TEST_SEAM_USAGE' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
+    settings-documentation = |{ c_docs_path-checks }test-seam-usage.md|.
 
     y_message_registration=>add_message(
       EXPORTING


### PR DESCRIPTION
I review the checks to set the address to the specific documentation for each one.

I found two particular cases:
- There is no documentation for check Equals sign chaining `y_check_equals_sign_chaining`
- There is a documentation for [Pseudo Comment Usage Check](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/pseudo-comment-usage.md), but the class doesn't exist