### PR TITLE
TR_CHECK_EXIST exception

### DIFF
--- a/clean_code_main/clean_code_foundation/y_exemption_general.clas.abap
+++ b/clean_code_main/clean_code_foundation/y_exemption_general.clas.abap
@@ -26,7 +26,7 @@ ENDCLASS.
 
 
 
-CLASS Y_EXEMPTION_GENERAL IMPLEMENTATION.
+CLASS y_exemption_general IMPLEMENTATION.
 
 
   METHOD is_object_exempted.
@@ -46,13 +46,15 @@ CLASS Y_EXEMPTION_GENERAL IMPLEMENTATION.
 
     CALL FUNCTION 'TR_CHECK_EXIST'
       EXPORTING
-        iv_pgmid    = 'R3TR'
-        iv_object   = l_object_type
-        iv_obj_name = l_object_name
+        iv_pgmid             = 'R3TR'
+        iv_object            = l_object_type
+        iv_obj_name          = l_object_name
       IMPORTING
-        e_exist     = existence_flag.
+        e_exist              = existence_flag
+      EXCEPTIONS
+        tr_no_check_function = 1.
 
-    IF existence_flag <> object_exists.
+    IF sy-subrc = 0 AND existence_flag <> object_exists.
       result = abap_true.
     ENDIF.
   ENDMETHOD.


### PR DESCRIPTION
Checking object types `FUGS` (and any other type not included in `OBJH` as `OBJECTTYPE = 'L'`) the function TR_CHECK_EXIST raise an exception that is not catched:
![image](https://user-images.githubusercontent.com/56556686/83856956-9cceac80-a71a-11ea-9f69-67ff9d686485.png)
