### PR TITLE
y_object_creation_date, less than 3 newlines between methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@ Legend
 + : added
 - : removed
 
-2020-XX-XX v1.07.0
+2020-11-11 v1.07.0
 ------------------
 * comment type exempt generated include
 * comment position for empty catches

--- a/docs/checks/constants-interface.md
+++ b/docs/checks/constants-interface.md
@@ -6,7 +6,8 @@
 
 ### What is the Intent of the Check?
 
-You should always prefer [enumeration](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#prefer-enumeration-classes-to-constants-interfaces) classes to constants interfaces.
+To avoid the creation and usage of an interface object for merely definying contants.
+You should always prefer [enumeration classes](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#prefer-enumeration-classes-to-constants-interfaces) to constants interfaces.
 
 ```abap
 CLASS /clean/message_severity DEFINITION PUBLIC ABSTRACT FINAL.

--- a/docs/checks/constants-interface.md
+++ b/docs/checks/constants-interface.md
@@ -32,7 +32,7 @@ ENDCLASS.
 
 ### How does the check work?
 
-The check searches for interfaces containing only constants.
+The "Constant Interface" check searches for interfaces containing only constants.
 
 ### Which attributes can be maintained?
 

--- a/src/foundation/y_object_creation_date.clas.abap
+++ b/src/foundation/y_object_creation_date.clas.abap
@@ -217,8 +217,6 @@ CLASS y_object_creation_date IMPLEMENTATION.
     ENDTRY.
   ENDMETHOD.
 
-
-
   METHOD try_new_created_on.
 
     DATA created_on_dates TYPE created_on_dates.


### PR DESCRIPTION
error found by abaplint,

code-pal-for-abap/src/foundation/y_object_creation_date.clas.abap:218: Less than 3 newlines and at least a single newline are required in between methods.(newline_between_methods)