### PR TITLE
fixing appl comp

### DIFF
--- a/src/foundation/y_check_base.clas.abap
+++ b/src/foundation/y_check_base.clas.abap
@@ -785,7 +785,7 @@ CLASS y_check_base IMPLEMENTATION.
         result = xsdbool( main_app_comp = curr_app_comp ).
       CATCH cx_sy_itab_line_not_found
             ycx_entry_not_found.
-        result = abap_false.
+        result = abap_true.
     ENDTRY.
   ENDMETHOD.
 


### PR DESCRIPTION
it the application component scan fails, the object is relevant for check (same behavior as it had in the past).