### PR TITLE
replace COND with xsdbool

### DIFF
--- a/src/checks/y_check_boolean_input_param.clas.abap
+++ b/src/checks/y_check_boolean_input_param.clas.abap
@@ -54,7 +54,7 @@ CLASS y_check_boolean_input_param IMPLEMENTATION.
 
   METHOD is_setter_method.
     DATA(method_name) = get_token_abs( statement-from + 1 ).
-    result = COND #( WHEN method_name CS 'SET_' THEN abap_true ).
+    result = xsdbool( method_name CS 'SET_' ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
found in abaplint regression testing, https://github.com/abaplint/abaplint/pull/1870, as https://rules.abaplint.org/use_bool_expression/ will cover more scenarios in the next release

follows https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#use-xsdbool-to-set-boolean-variables