### PR TITLE
Fix syntax errors in code example

### DIFF
--- a/docs/checks/method-output-parameter.md
+++ b/docs/checks/method-output-parameter.md
@@ -15,12 +15,12 @@ Use just one sort of output type per method.
 In exceptional cases, you can suppress this finding by using the pseudo comment `"#EC PARAMETER_OUT` which should be placed right after the method definition header:
 
 ```abap
-CLASS class_name DEFINITION.
+CLASS class_name DEFINITION PUBLIC.
   PUBLIC SECTION.
-    METHOD method_name
+    METHODS method_name
       EXPORTING param1 TYPE c
       CHANGING param2  TYPE c
-      RETURNING VALUE(result) TYPE c. "#EC PARAMETER_OUT
+      RETURNING VALUE(result) TYPE string. "#EC PARAMETER_OUT
 ENDCLASS.
 ```
 


### PR DESCRIPTION
- method->methods
- definition public
- c is not a valid returning parameter (not fully typed)