### PR TITLE
1.16.2 (updating branch)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,10 @@ Legend
 + : added
 - : removed
 
+2021-11-05 v.1.16.2
+------------------
+* Comment Position when Line Contains Pseudo Comment (#516)
+
 2021-11-03 v.1.16.1
 ------------------
 * DB Access in UT: False Positive (#513)

--- a/src/checks/y_check_comment_position.clas.abap
+++ b/src/checks/y_check_comment_position.clas.abap
@@ -115,7 +115,8 @@ CLASS y_check_comment_position IMPLEMENTATION.
   METHOD get_next_token.
     DATA(next_position) = current_position + 1.
     result = ref_scan->tokens[ next_position ].
-    IF is_pragma( result ) = abap_true.
+    IF is_pragma( result ) = abap_true
+    OR is_pseudo_comment( result ) = abap_true.
       result = get_next_token( next_position ).
     ENDIF.
   ENDMETHOD.
@@ -128,4 +129,5 @@ CLASS y_check_comment_position IMPLEMENTATION.
         result = abap_false.
     ENDTRY.
   ENDMETHOD.
+
 ENDCLASS.

--- a/src/checks/y_check_comment_position.clas.testclasses.abap
+++ b/src/checks/y_check_comment_position.clas.testclasses.abap
@@ -70,6 +70,7 @@ CLASS ltc_before_statement IMPLEMENTATION.
 ENDCLASS.
 
 
+
 CLASS ltc_empty_branch DEFINITION INHERITING FROM y_unit_test_base FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
   PROTECTED SECTION.
     METHODS get_cut REDEFINITION.
@@ -127,6 +128,7 @@ CLASS ltc_empty_branch IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
+
 
 
 CLASS ltc_empty_catch DEFINITION INHERITING FROM y_unit_test_base FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
@@ -193,6 +195,8 @@ CLASS ltc_empty_catch IMPLEMENTATION.
 
 ENDCLASS.
 
+
+
 CLASS ltc_inline DEFINITION INHERITING FROM y_unit_test_base FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
   PROTECTED SECTION.
     METHODS get_cut REDEFINITION.
@@ -241,6 +245,72 @@ CLASS ltc_inline IMPLEMENTATION.
       ( '     MESSAGE ID sy-msgid TYPE sy-msgty NUMBER sy-msgno INTO DATA(mtext) WITH sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4 ##NEEDED. ' )
       ( '     " TODO: Review Pseudo Comment ' )
       ( '     DATA(pseudo) = 1. "#EC SOMETHING ' )
+      ( '   ENDMETHOD. ' )
+      ( ' ENDCLASS. ' )
+    ).
+  ENDMETHOD.
+
+  METHOD get_code_with_exemption.
+    result = VALUE #( ).
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+
+CLASS ltc_pseudo_comment DEFINITION INHERITING FROM y_unit_test_base FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+  PROTECTED SECTION.
+    METHODS get_cut REDEFINITION.
+    METHODS get_code_with_issue REDEFINITION.
+    METHODS get_code_without_issue REDEFINITION.
+    METHODS get_code_with_exemption REDEFINITION.
+ENDCLASS.
+
+CLASS ltc_pseudo_comment IMPLEMENTATION.
+
+  METHOD get_cut.
+    result ?= NEW y_check_comment_position( ).
+  ENDMETHOD.
+
+  METHOD get_code_with_issue.
+    result = VALUE #(
+      ( 'REPORT y_example. ' )
+
+      ( ' CLASS y_example_class DEFINITION. ' )
+      ( '   PUBLIC SECTION. ' )
+      ( '     METHODS example. ' )
+      ( ' ENDCLASS. ' )
+
+      ( ' CLASS y_example_class IMPLEMENTATION. ' )
+      ( '   METHOD example. ' )
+      ( '     DATA lt_callstack TYPE sys_callst. ' )
+
+      ( '       " Reading stack for program ' )
+      ( '     READ TABLE lt_callstack "#EC CI_STDSEQ ' )
+      ( |       WITH KEY progname = 'SAPLEDOC_AIF' | )
+      ( '       TRANSPORTING NO FIELDS. ' )
+      ( '   ENDMETHOD. ' )
+      ( ' ENDCLASS. ' )
+    ).
+  ENDMETHOD.
+
+  METHOD get_code_without_issue.
+    result = VALUE #(
+      ( 'REPORT y_example. ' )
+
+      ( ' CLASS y_example_class DEFINITION. ' )
+      ( '   PUBLIC SECTION. ' )
+      ( '     METHODS example. ' )
+      ( ' ENDCLASS. ' )
+
+      ( ' CLASS y_example_class IMPLEMENTATION. ' )
+      ( '   METHOD example. ' )
+      ( '     DATA lt_callstack TYPE sys_callst. ' )
+
+      ( '     " Reading stack for program ' )
+      ( '     READ TABLE lt_callstack "#EC CI_STDSEQ ' )
+      ( |       WITH KEY progname = 'SAPLEDOC_AIF' | )
+      ( '       TRANSPORTING NO FIELDS. ' )
       ( '   ENDMETHOD. ' )
       ( ' ENDCLASS. ' )
     ).

--- a/src/y_code_pal_version.intf.abap
+++ b/src/y_code_pal_version.intf.abap
@@ -1,3 +1,3 @@
 INTERFACE y_code_pal_version PUBLIC. "#EC CONS_INTF
-  CONSTANTS abap TYPE string VALUE '1.16.1' ##NO_TEXT.
+  CONSTANTS abap TYPE string VALUE '1.16.2' ##NO_TEXT.
 ENDINTERFACE.


### PR DESCRIPTION
* 1.16.2

* Comment Position when Line Contains Pseudo Comment (#518)

* fixes #516

* Missing space between string or character literal and parentheses

Co-authored-by: Lucas Borin <5233413+lucasborin@users.noreply.github.co>

* updating changelog

Co-authored-by: Lucas Borin <5233413+lucasborin@users.noreply.github.co>