### PR TITLE
Fixing check Y_CHECK_PREFER_LINES_EXISTS

### DIFF
--- a/src/checks/y_check_prefer_line_exists.clas.abap
+++ b/src/checks/y_check_prefer_line_exists.clas.abap
@@ -7,8 +7,8 @@ CLASS y_check_prefer_line_exists DEFINITION PUBLIC INHERITING FROM y_check_base 
 
   PRIVATE SECTION.
     METHODS:
-      get_valid_last_token  IMPORTING last_token               TYPE stokesx
-                            RETURNING VALUE(valid_last_token)  TYPE abap_boolean,
+      get_valid_last_token  IMPORTING last_token              TYPE stokesx
+                            RETURNING VALUE(valid_last_token) TYPE abap_boolean,
       get_valid_first_token IMPORTING first_token              TYPE string
                             RETURNING VALUE(valid_first_token) TYPE abap_boolean.
 
@@ -79,20 +79,12 @@ CLASS y_check_prefer_line_exists IMPLEMENTATION.
                  check_configuration = check_configuration ).
   ENDMETHOD.
 
-  METHOD get_valid_last_token.
-    IF ( last_token-type = scan_token_type-comment OR last_token-type = scan_token_type-pragma ) OR ( last_token-str = 'ABAP_TRUE' OR last_token-str = 'ABAP_FALSE' ).
-      valid_last_token = abap_false.
-    ELSE.
-      valid_last_token = abap_true.
-    ENDIF.
+  METHOD get_valid_first_token.
+    valid_first_token = xsdbool( first_token = 'LOOP' OR first_token = 'ENDLOOP' OR first_token = 'EXIT' ).
   ENDMETHOD.
 
-  METHOD get_valid_first_token.
-    IF first_token = 'LOOP' OR first_token = 'ENDLOOP' OR first_token = 'EXIT'.
-      valid_first_token = abap_true.
-    ELSE.
-      valid_first_token = abap_false.
-    ENDIF.
+  METHOD get_valid_last_token.
+    valid_last_token = xsdbool( NOT ( last_token-type = scan_token_type-comment OR last_token-type = scan_token_type-pragma ) AND NOT ( last_token-str = 'ABAP_TRUE' OR last_token-str = 'ABAP_FALSE' ) ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/y_check_prefer_line_exists.clas.abap
+++ b/src/checks/y_check_prefer_line_exists.clas.abap
@@ -5,6 +5,13 @@ CLASS y_check_prefer_line_exists DEFINITION PUBLIC INHERITING FROM y_check_base 
   PROTECTED SECTION.
     METHODS inspect_tokens REDEFINITION.
 
+  PRIVATE SECTION.
+    METHODS:
+      get_valid_last_token  IMPORTING last_token               TYPE stokesx
+                            RETURNING VALUE(valid_last_token)  TYPE abap_boolean,
+      get_valid_first_token IMPORTING first_token              TYPE string
+                            RETURNING VALUE(valid_first_token) TYPE abap_boolean.
+
 ENDCLASS.
 
 
@@ -21,6 +28,7 @@ CLASS y_check_prefer_line_exists IMPLEMENTATION.
     settings-documentation = |{ c_docs_path-checks }prefer-line-exists.md|.
 
     set_check_message( 'Prefer LINE_EXISTS or LINE_INDEX to READ TABLE or LOOP AT!' ).
+
   ENDMETHOD.
 
 
@@ -48,6 +56,21 @@ CLASS y_check_prefer_line_exists IMPLEMENTATION.
       RETURN.
     ENDIF.
 
+    IF keyword = 'LOOP'.
+      DATA(loop_structure) = ref_scan->structures[ stmnt_from = index type = scan_struc_type-iteration ].
+      LOOP AT ref_scan->statements ASSIGNING FIELD-SYMBOL(<statement>) FROM loop_structure-stmnt_from TO loop_structure-stmnt_to.
+        DATA(first_token) = ref_scan->tokens[ <statement>-from ]-str.
+        IF NOT get_valid_first_token( first_token ).
+          DATA(last_token) = ref_scan->tokens[ <statement>-to ].
+          IF get_valid_last_token( last_token ).
+            RETURN.
+          ENDIF.
+        ENDIF.
+      ENDLOOP.
+    ENDIF.
+
+    DATA(line) = get_line_abs( statement-from ).
+
     DATA(check_configuration) = detect_check_configuration( statement ).
 
     raise_error( statement_level = statement-level
@@ -56,5 +79,20 @@ CLASS y_check_prefer_line_exists IMPLEMENTATION.
                  check_configuration = check_configuration ).
   ENDMETHOD.
 
+  METHOD get_valid_last_token.
+    IF ( last_token-type = scan_token_type-comment OR last_token-type = scan_token_type-pragma ) OR ( last_token-str = 'ABAP_TRUE' OR last_token-str = 'ABAP_FALSE' ).
+      valid_last_token = abap_false.
+    ELSE.
+      valid_last_token = abap_true.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD get_valid_first_token.
+    IF first_token = 'LOOP' OR first_token = 'ENDLOOP' OR first_token = 'EXIT'.
+      valid_first_token = abap_true.
+    ELSE.
+      valid_first_token = abap_false.
+    ENDIF.
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/y_check_prefer_line_exists.clas.testclasses.abap
+++ b/src/checks/y_check_prefer_line_exists.clas.testclasses.abap
@@ -144,7 +144,7 @@ ENDCLASS.
 
 CLASS ltc_loop_in DEFINITION INHERITING FROM ltc_loop_at FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
   PROTECTED SECTION.
-    METHODS get_code_without_issue REDEFINITION.
+    METHODS: get_code_without_issue REDEFINITION.
 ENDCLASS.
 
 CLASS ltc_loop_in IMPLEMENTATION.
@@ -159,6 +159,30 @@ CLASS ltc_loop_in IMPLEMENTATION.
 
       ( '   LOOP AT actual TRANSPORTING NO FIELDS WHERE obj_name IN expected. ' )
       ( '   EXIT. ' )
+      ( '   ENDLOOP. ' )
+    ).
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltc_loop_with_content DEFINITION INHERITING FROM ltc_loop_at FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+  PROTECTED SECTION.
+    METHODS: get_code_without_issue REDEFINITION.
+ENDCLASS.
+
+CLASS ltc_loop_with_content IMPLEMENTATION.
+
+  METHOD get_code_without_issue.
+     result = VALUE #(
+      ( 'REPORT y_example. ' )
+
+      ( ' START-OF-SELECTION.      ' )
+      ( '   DATA actual TYPE TABLE OF tadir. ' )
+      ( '   DATA counter TYPE i. ' )
+
+      ( conv #( `   LOOP AT actual TRANSPORTING NO FIELDS WHERE object = 'CLAS'. ` )  )
+      ( '   counter += 1. ' )
       ( '   ENDLOOP. ' )
     ).
   ENDMETHOD.

--- a/src/checks/y_check_prefer_line_exists.clas.testclasses.abap
+++ b/src/checks/y_check_prefer_line_exists.clas.testclasses.abap
@@ -174,17 +174,17 @@ ENDCLASS.
 CLASS ltc_loop_with_content IMPLEMENTATION.
 
   METHOD get_code_without_issue.
-     result = VALUE #(
-      ( 'REPORT y_example. ' )
+    result = VALUE #(
+     ( 'REPORT y_example. ' )
 
-      ( ' START-OF-SELECTION.      ' )
-      ( '   DATA actual TYPE TABLE OF tadir. ' )
-      ( '   DATA counter TYPE i. ' )
+     ( ' START-OF-SELECTION.      ' )
+     ( '   DATA actual TYPE TABLE OF tadir. ' )
+     ( '   DATA counter TYPE i. ' )
 
-      ( conv #( `   LOOP AT actual TRANSPORTING NO FIELDS WHERE object = 'CLAS'. ` )  )
-      ( '   counter += 1. ' )
-      ( '   ENDLOOP. ' )
-    ).
+     ( CONV #( `   LOOP AT actual TRANSPORTING NO FIELDS WHERE object = 'CLAS'. ` )  )
+     ( '   counter += 1. ' )
+     ( '   ENDLOOP. ' )
+   ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
closes #547 

Fixing the check Y_CHECK_PREFER_LINES_EXISTS. 
The check has reported iterations which include necessary statements. Due to that the statements within the iterations are necessary, the reporting of them as findings is incorrect. This should be solved now.