### PR TITLE
CL_ABAP_UNIT_ASSERT=>SKIP does not exist in 7.50

### DIFF
--- a/src/examples/y_demo_failures.clas.testclasses.abap
+++ b/src/examples/y_demo_failures.clas.testclasses.abap
@@ -17,7 +17,7 @@ CLASS local_test_class IMPLEMENTATION.
 
   METHOD external_call_in_ut.
     DATA alv TYPE REF TO cl_gui_alv_grid.
-    cl_abap_unit_assert=>skip( 'No Gui Allowed' ).
+    cl_abap_unit_assert=>abort( 'No Gui Allowed' ).
   ENDMETHOD.
 
   METHOD unit_test_assert.


### PR DESCRIPTION
Closes #586 