### PR TITLE
Comment Type: Ignore FM signatures

### DIFF
--- a/src/checks/y_check_comment_type.clas.abap
+++ b/src/checks/y_check_comment_type.clas.abap
@@ -5,8 +5,8 @@ CLASS y_check_comment_type DEFINITION PUBLIC INHERITING FROM y_check_base CREATE
     METHODS inspect_tokens REDEFINITION.
   PRIVATE SECTION.
     METHODS has_wrong_comment_type IMPORTING statement TYPE sstmnt RETURNING VALUE(result) TYPE abap_bool.
-    METHODS get_first_character IMPORTING token TYPE stokesx RETURNING VALUE(result) TYPE char1.
-    METHODS get_second_character IMPORTING token TYPE stokesx RETURNING VALUE(result) TYPE char1.
+
+
 ENDCLASS.
 
 
@@ -41,9 +41,17 @@ CLASS y_check_comment_type IMPLEMENTATION.
 
   METHOD has_wrong_comment_type.
     LOOP AT ref_scan->tokens ASSIGNING FIELD-SYMBOL(<token>)
-    FROM statement-from TO statement-to.
-      IF get_first_character( <token> ) = '*'
-      AND get_second_character( <token> ) <> '&'.
+    FROM statement-from TO statement-to
+    WHERE type = scan_token_type-comment.
+      IF has_token_started_with( token = <token>-str
+                                 start_with = |*"| )
+          OR has_token_started_with( token = <token>-str
+                                     start_with = |*&| ).
+        CONTINUE.
+      ENDIF.
+
+      IF has_token_started_with( token = <token>-str
+                                 start_with = |*| ).
         result = abap_true.
         RETURN.
       ENDIF.
@@ -51,20 +59,4 @@ CLASS y_check_comment_type IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_first_character.
-    TRY.
-        result = token-str(1).
-      CATCH cx_sy_range_out_of_bounds.
-        result = ''.
-    ENDTRY.
-  ENDMETHOD.
-
-
-  METHOD get_second_character.
-    TRY.
-        result = token-str(2).
-      CATCH cx_sy_range_out_of_bounds.
-        result = ''.
-    ENDTRY.
-  ENDMETHOD.
 ENDCLASS.

--- a/src/checks/y_check_comment_type.clas.abap
+++ b/src/checks/y_check_comment_type.clas.abap
@@ -43,18 +43,22 @@ CLASS y_check_comment_type IMPLEMENTATION.
     LOOP AT ref_scan->tokens ASSIGNING FIELD-SYMBOL(<token>)
     FROM statement-from TO statement-to
     WHERE type = scan_token_type-comment.
-      IF has_token_started_with( token = <token>-str
-                                 start_with = |*"| )
-          OR has_token_started_with( token = <token>-str
-                                     start_with = |*&| ).
-        CONTINUE.
-      ENDIF.
+      TRY.
+          IF has_token_started_with( token = <token>-str
+                                     start_with = |*"| )
+              OR has_token_started_with( token = <token>-str
+                                         start_with = |*&| ).
+            CONTINUE.
+          ENDIF.
 
-      IF has_token_started_with( token = <token>-str
-                                 start_with = |*| ).
-        result = abap_true.
-        RETURN.
-      ENDIF.
+          IF has_token_started_with( token = <token>-str
+                                     start_with = |*| ).
+            result = abap_true.
+            RETURN.
+          ENDIF.
+        CATCH cx_sy_range_out_of_bounds.
+          result = abap_false.
+      ENDTRY.
     ENDLOOP.
   ENDMETHOD.
 

--- a/src/checks/y_check_comment_type.clas.testclasses.abap
+++ b/src/checks/y_check_comment_type.clas.testclasses.abap
@@ -71,3 +71,40 @@ CLASS ltc_generated_include IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
+
+CLASS ltc_function_module_signature DEFINITION INHERITING FROM ltc_asterisk FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+  PROTECTED SECTION.
+    METHODS get_code_with_issue REDEFINITION.
+    METHODS get_code_without_issue REDEFINITION.
+ENDCLASS.
+
+CLASS ltc_function_module_signature IMPLEMENTATION.
+
+  METHOD get_code_with_issue.
+    result = VALUE #(
+      ( 'FUNCTION-POOL SDCB. ' )
+      ( 'FUNCTION CALL_BROWSER. ' )
+      ( '*"----------------------------------------------------------------------' )
+      ( '*"*"Local Interface:                                                    ' )
+      ( '*"  IMPORTING                                                           ' )
+      ( '*"     VALUE(import) TYPE  string                                       ' )
+      ( '*"----------------------------------------------------------------------' )
+      ( '*    anti-pattern                                                       ' )
+      ( 'ENDFUNCTION.                                                            ' )
+    ).
+  ENDMETHOD.
+
+  METHOD get_code_without_issue.
+    result = VALUE #(
+      ( 'FUNCTION-POOL SDCB. ' )
+      ( 'FUNCTION CALL_BROWSER. ' )
+      ( '*"----------------------------------------------------------------------' )
+      ( '*"*"Local Interface:                                                    ' )
+      ( '*"  IMPORTING                                                           ' )
+      ( '*"     VALUE(import) TYPE  string                                       ' )
+      ( '*"----------------------------------------------------------------------' )
+      ( 'ENDFUNCTION.                                                            ' )
+    ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/checks/y_check_comment_usage.clas.abap
+++ b/src/checks/y_check_comment_usage.clas.abap
@@ -16,17 +16,12 @@ CLASS y_check_comment_usage DEFINITION PUBLIC INHERITING FROM y_check_base CREAT
 
     METHODS check_result IMPORTING structure TYPE sstruc.
 
-    METHODS is_code_disabled IMPORTING structure TYPE sstruc
-                                       statement TYPE sstmnt
+    METHODS is_code_disabled IMPORTING structure     TYPE sstruc
+                                       statement     TYPE sstmnt
                              RETURNING VALUE(result) TYPE abap_bool.
 
-    METHODS is_comment_excluded IMPORTING token TYPE string
+    METHODS is_comment_excluded IMPORTING token         TYPE string
                                 RETURNING VALUE(result) TYPE abap_bool.
-
-    METHODS has_token_started_with IMPORTING token TYPE string
-                                             start_with TYPE string
-                                   RETURNING VALUE(result) TYPE abap_bool
-                                   RAISING cx_sy_range_out_of_bounds.
 
     METHODS is_badi_example_class RETURNING VALUE(result) TYPE abap_bool.
 ENDCLASS.
@@ -94,40 +89,30 @@ CLASS y_check_comment_usage IMPLEMENTATION.
 
   METHOD is_comment_excluded.
     TRY.
-      IF has_token_started_with( token = token
-                                 start_with = |*"| )
-        OR has_token_started_with( token = token
-                                   start_with = |"!| )
-        OR has_token_started_with( token = token
-                                   start_with = |##| )
-        OR has_token_started_with( token = token
-                                   start_with = |*?| )
-        OR has_token_started_with( token = token
-                                   start_with = |"?| )
-        OR has_token_started_with( token = token
-                                   start_with = |*&| )
-        OR has_token_started_with( token = token
-                                   start_with = |"#EC| )
-        OR has_token_started_with( token = token
-                                   start_with = |* INCLUDE| )
-        OR token CP |"{ object_name }*.|
-        OR token CO |*|.
+        IF has_token_started_with( token = token
+                                   start_with = |*"| )
+            OR has_token_started_with( token = token
+                                       start_with = |"!| )
+            OR has_token_started_with( token = token
+                                       start_with = |##| )
+            OR has_token_started_with( token = token
+                                       start_with = |*?| )
+            OR has_token_started_with( token = token
+                                       start_with = |"?| )
+            OR has_token_started_with( token = token
+                                       start_with = |*&| )
+            OR has_token_started_with( token = token
+                                       start_with = |"#EC| )
+            OR has_token_started_with( token = token
+                                       start_with = |* INCLUDE| )
+            OR token CP |"{ object_name }*.|
+            OR token CO |*|.
 
-      result = abap_true.
-
-      ENDIF.
-    CATCH cx_sy_range_out_of_bounds.
-      result = abap_false.
+          result = abap_true.
+        ENDIF.
+      CATCH cx_sy_range_out_of_bounds.
+        result = abap_false.
     ENDTRY.
-  ENDMETHOD.
-
-  METHOD has_token_started_with.
-    DATA(token_length) = strlen( start_with ).
-    IF substring( val = token
-                  off = 0
-                  len = token_length ) = start_with.
-      result = abap_true.
-    ENDIF.
   ENDMETHOD.
 
   METHOD check_result.
@@ -178,7 +163,7 @@ CLASS y_check_comment_usage IMPLEMENTATION.
     INTO @DATA(enhancement)
     WHERE obj_type = @object_type
     AND obj_name = @object_name
-    AND VERSION = 'A'.
+    AND version = 'A'.
 
     result = xsdbool( enhancement IS NOT INITIAL ).
   ENDMETHOD.

--- a/src/foundation/y_check_base.clas.abap
+++ b/src/foundation/y_check_base.clas.abap
@@ -114,6 +114,11 @@ CLASS y_check_base DEFINITION PUBLIC ABSTRACT
 
     methods get_docu_for_test redefinition.
 
+    METHODS has_token_started_with IMPORTING token TYPE string
+                                             start_with TYPE string
+                                   RETURNING VALUE(result) TYPE abap_bool
+                                   RAISING cx_sy_range_out_of_bounds.
+
   PRIVATE SECTION.
     METHODS do_attributes_exist  RETURNING VALUE(result) TYPE abap_bool.
 
@@ -697,6 +702,16 @@ CLASS Y_CHECK_BASE IMPLEMENTATION.
         iv_trdir_name = level-name
       IMPORTING
         es_tadir_keys = result.
+  ENDMETHOD.
+
+
+  METHOD has_token_started_with.
+    DATA(token_length) = strlen( start_with ).
+    IF substring( val = token
+                  off = 0
+                  len = token_length ) = start_with.
+      result = abap_true.
+    ENDIF.
   ENDMETHOD.
 
 

--- a/src/profiles/y_list.clas.testclasses.abap
+++ b/src/profiles/y_list.clas.testclasses.abap
@@ -206,10 +206,9 @@ CLASS lcl_list_ut IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_table.
-    DATA dta  TYPE REF TO data.
     FIELD-SYMBOLS: <table> TYPE STANDARD TABLE.
 
-    dta = cut->get_table( ).
+    DATA(dta) = cut->get_table( ).
 
     ASSIGN dta->* TO <table>.
 


### PR DESCRIPTION
1. Move `has_token_started_with()` to base class, for use in both Comment Type and Comment Usage checks
2. Ignore FM signatures (*") for Comment Type check

Fixes https://github.com/SAP/code-pal-for-abap/issues/589