### PR TITLE
Recommendations

### DIFF
--- a/src/checks/y_check_branch_coverage.clas.abap
+++ b/src/checks/y_check_branch_coverage.clas.abap
@@ -25,7 +25,7 @@ CLASS y_check_branch_coverage IMPLEMENTATION.
     settings-ignore_pseudo_comments = abap_true.
     settings-documentation = |{ c_docs_path-checks }unit-test-coverages.md|.
 
-    set_check_message( 'Branch Coverage must be higher than &2%! (&1%<=&2%)' ).
+    set_check_message( 'Branch Coverage should be higher than &2%! (&1%<=&2%)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_branch_coverage.clas.abap
+++ b/src/checks/y_check_branch_coverage.clas.abap
@@ -25,7 +25,7 @@ CLASS y_check_branch_coverage IMPLEMENTATION.
     settings-ignore_pseudo_comments = abap_true.
     settings-documentation = |{ c_docs_path-checks }unit-test-coverages.md|.
 
-    set_check_message( 'Branch Coverage should be higher than &2%! (&1%<=&2%)' ).
+    set_check_message( 'Branch coverage should be higher than &2%! (&1%<=&2%)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_comment_usage.clas.abap
+++ b/src/checks/y_check_comment_usage.clas.abap
@@ -45,7 +45,7 @@ CLASS y_check_comment_usage IMPLEMENTATION.
                                         ( scan_struc_stmnt_type-function )
                                         ( scan_struc_stmnt_type-module ) ).
 
-    set_check_message( 'Percentage of comments must be lower than &3% of the productive code! (&2%>=&3%) (&1 lines found)' ).
+    set_check_message( 'Percentage of comments should be lower than &3% of the productive code! (&2%>=&3%) (&1 lines found)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_cyclomatic_complexity.clas.abap
+++ b/src/checks/y_check_cyclomatic_complexity.clas.abap
@@ -58,7 +58,7 @@ CLASS Y_CHECK_CYCLOMATIC_COMPLEXITY IMPLEMENTATION.
     settings-threshold = 10.
     settings-documentation = |{ c_docs_path-checks }cyclomatic-complexity.md|.
 
-    set_check_message( 'Cyclomatic complexity must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Cyclomatic complexity should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_max_nesting_depth.clas.abap
+++ b/src/checks/y_check_max_nesting_depth.clas.abap
@@ -61,7 +61,7 @@ CLASS y_check_max_nesting_depth IMPLEMENTATION.
     settings-pseudo_comment = '"#EC CI_NESTING' ##NO_TEXT.
     settings-documentation = |{ c_docs_path-checks }maximum-nesting-depth.md|.
 
-    set_check_message( 'Nesting depth must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Nesting depth should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_num_exec_statements.clas.abap
+++ b/src/checks/y_check_num_exec_statements.clas.abap
@@ -36,7 +36,7 @@ CLASS Y_CHECK_NUM_EXEC_STATEMENTS IMPLEMENTATION.
 
     add_obj_type( c_type_program ).
 
-    set_check_message( 'Number of executable statements must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Number of executable statements should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_num_output_parameter.clas.abap
+++ b/src/checks/y_check_num_output_parameter.clas.abap
@@ -28,7 +28,7 @@ CLASS y_check_num_output_parameter IMPLEMENTATION.
 
     relevant_structure_types = VALUE #( ).
 
-    set_check_message( 'Number of output parameters must be less than &2! (but is &1)' ).
+    set_check_message( 'Number of output parameters should be less than &2! (but is &1)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_number_attributes.clas.abap
+++ b/src/checks/y_check_number_attributes.clas.abap
@@ -38,7 +38,7 @@ CLASS y_check_number_attributes IMPLEMENTATION.
 
     relevant_structure_types = VALUE #( ).
 
-    set_check_message( 'Number of attributes must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Number of attributes should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_number_events.clas.abap
+++ b/src/checks/y_check_number_events.clas.abap
@@ -29,7 +29,7 @@ CLASS Y_CHECK_NUMBER_EVENTS IMPLEMENTATION.
 
     relevant_structure_types = VALUE #( ).
 
-    set_check_message( 'Number of events must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Number of events should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_number_interfaces.clas.abap
+++ b/src/checks/y_check_number_interfaces.clas.abap
@@ -30,7 +30,7 @@ CLASS y_check_number_interfaces IMPLEMENTATION.
 
     relevant_structure_types = VALUE #( ).
 
-    set_check_message( 'Number of interfaces must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Number of interfaces should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_number_methods.clas.abap
+++ b/src/checks/y_check_number_methods.clas.abap
@@ -31,7 +31,7 @@ CLASS Y_CHECK_NUMBER_METHODS IMPLEMENTATION.
 
     relevant_structure_types = VALUE #( ).
 
-    set_check_message( 'Number of methods must be lower than &2! (&1>=&2)' ).
+    set_check_message( 'Number of methods should be lower than &2! (&1>=&2)' ).
   ENDMETHOD.
 
 

--- a/src/checks/y_check_procedure_coverage.clas.abap
+++ b/src/checks/y_check_procedure_coverage.clas.abap
@@ -25,7 +25,7 @@ CLASS y_check_procedure_coverage IMPLEMENTATION.
     settings-ignore_pseudo_comments = abap_true.
     settings-documentation = |{ c_docs_path-checks }unit-test-coverages.md|.
 
-    set_check_message( 'Procedure Coverage must be higher than &2%! (&1%<=&2%)' ).
+    set_check_message( 'Procedure coverage should be higher than &2%! (&1%<=&2%)' ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
Fixes #631 

Adjusted "must" to "should" in all short texts that relate to recommended statistics (coverage, comment ratios, method signatures, etc.)