### PR TITLE
Fix attributes when no profile is present

### DIFF
--- a/src/foundation/y_check_base.clas.abap
+++ b/src/foundation/y_check_base.clas.abap
@@ -250,7 +250,7 @@ CLASS Y_CHECK_BASE IMPLEMENTATION.
         DATA(profiles) = y_profile_manager=>create( )->select_profiles( sy-uname ).
         result = xsdbool( profiles IS NOT INITIAL ).
       CATCH ycx_entry_not_found.
-        result = abap_true.
+        result = abap_false.
     ENDTRY.
   ENDMETHOD.
 

--- a/src/profiles/y_profile_manager.clas.abap
+++ b/src/profiles/y_profile_manager.clas.abap
@@ -356,7 +356,6 @@ CLASS y_profile_manager IMPLEMENTATION.
     LOOP AT result ASSIGNING FIELD-SYMBOL(<line>) WHERE username <> username AND is_standard = abap_true.
       <line>-username = username.
     ENDLOOP.
-    UNASSIGN <line>.
   ENDMETHOD.
 
 


### PR DESCRIPTION
The profile manager interface is badly designed and throws exceptions for normal situations (like no profile existing for the current user), but for now we just treat the exception correctly

Fixes #637 